### PR TITLE
feat: add newsroom experience for Newside Studio

### DIFF
--- a/src/renderer/src/Router.tsx
+++ b/src/renderer/src/Router.tsx
@@ -14,6 +14,7 @@ import FilesPage from './pages/files/FilesPage'
 import HomePage from './pages/home/HomePage'
 import KnowledgePage from './pages/knowledge/KnowledgePage'
 import LaunchpadPage from './pages/launchpad/LaunchpadPage'
+import NewsroomPage from './pages/newsroom/NewsroomPage'
 import MinAppPage from './pages/minapps/MinAppPage'
 import MinAppsPage from './pages/minapps/MinAppsPage'
 import NotesPage from './pages/notes/NotesPage'
@@ -34,6 +35,7 @@ const Router: FC = () => {
           <Route path="/translate" element={<TranslatePage />} />
           <Route path="/files" element={<FilesPage />} />
           <Route path="/notes" element={<NotesPage />} />
+          <Route path="/newsroom" element={<NewsroomPage />} />
           <Route path="/knowledge" element={<KnowledgePage />} />
           <Route path="/apps/:appId" element={<MinAppPage />} />
           <Route path="/apps" element={<MinAppsPage />} />

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Folder,
   Languages,
   LayoutGrid,
+  Newspaper,
   MessageSquare,
   Monitor,
   Moon,
@@ -139,7 +140,8 @@ const MainMenus: FC = () => {
     knowledge: <FileSearch size={18} className="icon" />,
     files: <Folder size={18} className="icon" />,
     notes: <NotepadText size={18} className="icon" />,
-    code_tools: <Code size={18} className="icon" />
+    code_tools: <Code size={18} className="icon" />,
+    newsroom: <Newspaper size={18} className="icon" />
   }
 
   const pathMap = {
@@ -151,7 +153,8 @@ const MainMenus: FC = () => {
     knowledge: '/knowledge',
     files: '/files',
     code_tools: '/code',
-    notes: '/notes'
+    notes: '/notes',
+    newsroom: '/newsroom'
   }
 
   return sidebarIcons.visible.map((icon) => {

--- a/src/renderer/src/config/sidebar.ts
+++ b/src/renderer/src/config/sidebar.ts
@@ -7,6 +7,7 @@ import { SidebarIcon } from '@renderer/types'
 export const DEFAULT_SIDEBAR_ICONS: SidebarIcon[] = [
   'assistants',
   'agents',
+  'newsroom',
   'paintings',
   'translate',
   'minapp',

--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -163,7 +163,8 @@ const sidebarIconKeyMap = {
   knowledge: 'knowledge.title',
   files: 'files.title',
   code_tools: 'code.title',
-  notes: 'notes.title'
+  notes: 'notes.title',
+  newsroom: 'newsroom.title'
 } as const
 
 export const getSidebarIconLabel = (key: string): string => {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1682,6 +1682,9 @@
   "navigate": {
     "provider_settings": "Go to provider settings"
   },
+  "newsroom": {
+    "title": "Newsroom"
+  },
   "notes": {
     "characters": "Characters",
     "collapse": "Collapse",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1683,6 +1683,9 @@
   "navigate": {
     "provider_settings": "跳转到服务商设置界面"
   },
+  "newsroom": {
+    "title": "新闻工作站"
+  },
   "notes": {
     "characters": "字符",
     "collapse": "收起",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1682,6 +1682,9 @@
   "navigate": {
     "provider_settings": "跳轉到服務商設置界面"
   },
+  "newsroom": {
+    "title": "新聞工作站"
+  },
   "notes": {
     "characters": "字符",
     "collapse": "收起",

--- a/src/renderer/src/pages/newsroom/NewsroomPage.tsx
+++ b/src/renderer/src/pages/newsroom/NewsroomPage.tsx
@@ -1,0 +1,808 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  Divider,
+  Empty,
+  Flex,
+  Input,
+  List,
+  Modal,
+  Progress,
+  Segmented,
+  Select,
+  Space,
+  Switch,
+  Tag,
+  Tooltip
+} from 'antd'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import {
+  AlertTriangle,
+  BarChart3,
+  CheckCircle2,
+  Clock,
+  Layers3,
+  Link2,
+  PlayCircle,
+  ShieldCheck,
+  Sparkles,
+  Workflow
+} from 'lucide-react'
+import { FC } from 'react'
+import styled from 'styled-components'
+
+import { MOCK_EVENTS, MOCK_PLUGINS, MOCK_PRESETS, MOCK_TRENDS } from './mockData'
+import type {
+  FactCheckInsight,
+  FactCheckVerdict,
+  MarketPlugin,
+  NewsroomEvent,
+  NewsroomFilterState,
+  TrendInsight
+} from './types'
+
+dayjs.extend(relativeTime)
+
+type FactCheckState = {
+  visible: boolean
+  loading: boolean
+  event?: NewsroomEvent
+  result?: FactCheckInsight
+}
+
+const TIMEFRAME_LIMITS: Record<NewsroomFilterState['timeframe'], number> = {
+  '1h': 60,
+  '6h': 360,
+  '24h': 1440,
+  '7d': 10080
+}
+
+const sentimentOptions = [
+  { label: 'All sentiments', value: 'all' },
+  { label: 'Positive', value: 'positive' },
+  { label: 'Neutral', value: 'neutral' },
+  { label: 'Negative', value: 'negative' }
+]
+
+const riskOptions = [
+  { label: 'All priorities', value: 'all' },
+  { label: 'High priority', value: 'high' },
+  { label: 'Medium priority', value: 'medium' },
+  { label: 'Low priority', value: 'low' }
+]
+
+/**
+ * 创建事实核查结果的模拟数据
+ */
+const createMockFactCheck = (event: NewsroomEvent): FactCheckInsight => {
+  const verdict: FactCheckVerdict = event.reliability >= 90 ? 'verified' : event.reliability >= 75 ? 'needs_review' : 'debunked'
+
+  return {
+    verdict,
+    summary: `Perplexity Sonar cross-referenced ${event.articles.length} independent sources and MCP fact-check plugins to validate the latest signals for “${event.title}”.`,
+    references: event.articles.slice(0, 3).map((article, index) => ({
+      title: article.headline,
+      url: article.url,
+      stance: index === 0 ? 'supporting' : index === 1 ? 'neutral' : 'supporting'
+    })),
+    riskNotes: [
+      verdict === 'debunked'
+        ? 'Confidence flagged due to conflicting eyewitness accounts.'
+        : 'No direct contradictions detected across structured feeds and MCP archives.',
+      'Recommend rerunning verification when new primary sources arrive.'
+    ],
+    aiConfidence: Math.min(99, Math.round(event.reliability + 6)),
+    latencyMs: 2300 + event.articles.length * 180
+  }
+}
+
+/**
+ * 新闻聚合首页
+ */
+const NewsroomPage: FC = () => {
+  const [filters, setFilters] = useState<NewsroomFilterState>({
+    timeframe: '6h',
+    categories: [],
+    regions: [],
+    sentiment: 'all',
+    risk: 'all',
+    sources: [],
+    query: '',
+    onlyPriority: false
+  })
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(MOCK_EVENTS[0]?.id ?? null)
+  const [factCheckState, setFactCheckState] = useState<FactCheckState>({ visible: false, loading: false })
+
+  const categories = useMemo(() => Array.from(new Set(MOCK_EVENTS.map((event) => event.category))), [])
+  const regions = useMemo(
+    () => Array.from(new Set(MOCK_EVENTS.flatMap((event) => event.regions))).filter(Boolean),
+    []
+  )
+  const sources = useMemo(
+    () => Array.from(new Set(MOCK_EVENTS.flatMap((event) => event.articles.map((article) => article.outlet)))),
+    []
+  )
+
+  const filteredEvents = useMemo(() => {
+    return MOCK_EVENTS.filter((event) => {
+      if (filters.onlyPriority && event.priority !== 'high') {
+        return false
+      }
+
+      const timeframeLimit = TIMEFRAME_LIMITS[filters.timeframe]
+      if (event.freshnessMinutes > timeframeLimit) {
+        return false
+      }
+
+      if (filters.categories.length > 0 && !filters.categories.includes(event.category)) {
+        return false
+      }
+
+      if (filters.regions.length > 0 && !event.regions.some((region) => filters.regions.includes(region))) {
+        return false
+      }
+
+      if (filters.sources.length > 0 && !event.articles.some((article) => filters.sources.includes(article.outlet))) {
+        return false
+      }
+
+      if (filters.sentiment !== 'all' && event.sentiment !== filters.sentiment) {
+        return false
+      }
+
+      if (filters.risk !== 'all' && event.riskLevel !== filters.risk) {
+        return false
+      }
+
+      if (filters.query.trim()) {
+        const keyword = filters.query.trim().toLowerCase()
+        const haystack = [event.title, event.summary, ...event.tags].join(' ').toLowerCase()
+        return haystack.includes(keyword)
+      }
+
+      return true
+    })
+  }, [filters])
+
+  const selectedEvent = useMemo(
+    () => filteredEvents.find((event) => event.id === selectedEventId) ?? filteredEvents[0],
+    [filteredEvents, selectedEventId]
+  )
+
+  useEffect(() => {
+    if (filteredEvents.length === 0) {
+      setSelectedEventId(null)
+      return
+    }
+    if (!filteredEvents.some((event) => event.id === selectedEventId)) {
+      setSelectedEventId(filteredEvents[0].id)
+    }
+  }, [filteredEvents, selectedEventId])
+
+  /**
+   * 更新筛选条件
+   */
+  const handleFiltersChange = useCallback((partial: Partial<NewsroomFilterState>) => {
+    setFilters((prev) => ({ ...prev, ...partial }))
+  }, [])
+
+  /**
+   * 触发事实核查流程
+   */
+  const handleFactCheck = useCallback((event: NewsroomEvent) => {
+    setFactCheckState({ visible: true, loading: true, event })
+    window.setTimeout(() => {
+      setFactCheckState({ visible: true, loading: false, event, result: createMockFactCheck(event) })
+    }, 1200)
+  }, [])
+
+  /**
+   * 关闭事实核查窗口
+   */
+  const closeFactCheckModal = useCallback(() => {
+    setFactCheckState({ visible: false, loading: false })
+  }, [])
+
+  return (
+    <PageContainer>
+      <FiltersColumn>
+        <FilterPanel
+          categories={categories}
+          regions={regions}
+          sources={sources}
+          filters={filters}
+          onFiltersChange={handleFiltersChange}
+        />
+      </FiltersColumn>
+      <FeedColumn>
+        <EventBoard
+          events={filteredEvents}
+          selectedEventId={selectedEvent?.id ?? null}
+          onSelectEvent={setSelectedEventId}
+          onFactCheck={handleFactCheck}
+        />
+        <EventDetail event={selectedEvent ?? null} />
+      </FeedColumn>
+      <TrendColumn>
+        <TrendSidebar trends={MOCK_TRENDS} presets={MOCK_PRESETS} plugins={MOCK_PLUGINS} />
+      </TrendColumn>
+      <FactCheckModal state={factCheckState} onClose={closeFactCheckModal} />
+    </PageContainer>
+  )
+}
+
+type FilterPanelProps = {
+  categories: string[]
+  regions: string[]
+  sources: string[]
+  filters: NewsroomFilterState
+  onFiltersChange: (filters: Partial<NewsroomFilterState>) => void
+}
+
+/**
+ * 筛选器面板
+ */
+const FilterPanel: FC<FilterPanelProps> = ({ categories, regions, sources, filters, onFiltersChange }) => {
+  return (
+    <Card title="Signal Controls" bordered={false} styles={{ body: { display: 'flex', flexDirection: 'column', gap: 12 } }}>
+      <Input.Search
+        allowClear
+        placeholder="Search topics, tags, or sources"
+        value={filters.query}
+        onChange={(event) => onFiltersChange({ query: event.target.value })}
+      />
+      <div>
+        <Label>Time horizon</Label>
+        <Segmented
+          block
+          value={filters.timeframe}
+          onChange={(value) => onFiltersChange({ timeframe: value as NewsroomFilterState['timeframe'] })}
+          options={[
+            { label: '1h', value: '1h' },
+            { label: '6h', value: '6h' },
+            { label: '24h', value: '24h' },
+            { label: '7d', value: '7d' }
+          ]}
+        />
+      </div>
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="Focus categories"
+        value={filters.categories}
+        options={categories.map((category) => ({ label: category, value: category }))}
+        onChange={(value) => onFiltersChange({ categories: value })}
+      />
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="Regions"
+        value={filters.regions}
+        options={regions.map((region) => ({ label: region, value: region }))}
+        onChange={(value) => onFiltersChange({ regions: value })}
+      />
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="Preferred sources"
+        value={filters.sources}
+        options={sources.map((source) => ({ label: source, value: source }))}
+        onChange={(value) => onFiltersChange({ sources: value })}
+      />
+      <Select
+        value={filters.sentiment}
+        options={sentimentOptions}
+        onChange={(value) => onFiltersChange({ sentiment: value as NewsroomFilterState['sentiment'] })}
+      />
+      <Select
+        value={filters.risk}
+        options={riskOptions}
+        onChange={(value) => onFiltersChange({ risk: value as NewsroomFilterState['risk'] })}
+      />
+      <Checkbox checked={filters.onlyPriority} onChange={(event) => onFiltersChange({ onlyPriority: event.target.checked })}>
+        Only show urgent clusters
+      </Checkbox>
+      <Divider style={{ margin: '8px 0' }} />
+      <Space direction="vertical" size={8}>
+        <Flex align="center" gap={8}>
+          <ShieldCheck size={16} />
+          <span>De-duplication by MCP plugins is active.</span>
+        </Flex>
+        <Flex align="center" gap={8}>
+          <Sparkles size={16} />
+          <span>Personalized scoring adapts to newsroom interests.</span>
+        </Flex>
+      </Space>
+    </Card>
+  )
+}
+
+type EventBoardProps = {
+  events: NewsroomEvent[]
+  selectedEventId: string | null
+  onSelectEvent: (eventId: string | null) => void
+  onFactCheck: (event: NewsroomEvent) => void
+}
+
+/**
+ * 事件列表
+ */
+const EventBoard: FC<EventBoardProps> = ({ events, selectedEventId, onSelectEvent, onFactCheck }) => {
+  if (events.length === 0) {
+    return (
+      <Card bordered={false} style={{ flex: 1 }}>
+        <Empty description="No matching signals in this window." />
+      </Card>
+    )
+  }
+
+  return (
+    <Card bordered={false} title="Event intelligence" extra={<Badge count={events.length} color="blue" />}>
+      <EventList>
+        {events.map((event) => (
+          <EventCard
+            key={event.id}
+            event={event}
+            active={event.id === selectedEventId}
+            onSelect={() => onSelectEvent(event.id)}
+            onFactCheck={() => onFactCheck(event)}
+          />
+        ))}
+      </EventList>
+    </Card>
+  )
+}
+
+type EventCardProps = {
+  event: NewsroomEvent
+  active: boolean
+  onSelect: () => void
+  onFactCheck: () => void
+}
+
+/**
+ * 事件卡片
+ */
+const EventCard: FC<EventCardProps> = ({ event, active, onSelect, onFactCheck }) => {
+  const priorityColor = event.priority === 'high' ? 'volcano' : event.priority === 'medium' ? 'gold' : 'green'
+  const momentumLabel = `${event.articles.length} sources`
+
+  return (
+    <EventCardContainer $active={active} onClick={onSelect}>
+      <Flex justify="space-between" align="center">
+        <Flex align="center" gap={8}>
+          <Badge color={priorityColor} text={event.priority.toUpperCase()} />
+          <span className="event-title">{event.title}</span>
+        </Flex>
+        <Flex gap={8} align="center">
+          <Tooltip title="Confidence score from Sonar + MCP">
+            <Tag color="blue">Reliability {event.reliability}%</Tag>
+          </Tooltip>
+          <Tooltip title="Minutes since latest update">
+            <Tag icon={<Clock size={14} />}>{event.freshnessMinutes}m</Tag>
+          </Tooltip>
+        </Flex>
+      </Flex>
+      <Summary>{event.summary}</Summary>
+      <Flex wrap gap={6}>
+        {event.tags.map((tag) => (
+          <Tag key={tag}>{tag}</Tag>
+        ))}
+        {event.regions.map((region) => (
+          <Tag key={region} color="cyan">
+            {region}
+          </Tag>
+        ))}
+      </Flex>
+      <Flex justify="space-between" align="center">
+        <Metrics>
+          <span>
+            <BarChart3 size={14} /> Impact {event.impactScore}%
+          </span>
+          <span>
+            <Layers3 size={14} /> Coverage {event.coverageScore}%
+          </span>
+          <span>{momentumLabel}</span>
+        </Metrics>
+        <Space>
+          <Button
+            size="small"
+            icon={<ShieldCheck size={14} />}
+            onClick={(eventInstance) => {
+              eventInstance.stopPropagation()
+              onFactCheck()
+            }}>
+            Fact Check
+          </Button>
+          <Button
+            size="small"
+            icon={<Sparkles size={14} />}
+            type="primary"
+            onClick={(eventInstance) => {
+              eventInstance.stopPropagation()
+              onSelect()
+            }}>
+            Open Brief
+          </Button>
+        </Space>
+      </Flex>
+    </EventCardContainer>
+  )
+}
+
+type EventDetailProps = {
+  event: NewsroomEvent | null
+}
+
+/**
+ * 事件详细信息
+ */
+const EventDetail: FC<EventDetailProps> = ({ event }) => {
+  if (!event) {
+    return (
+      <Card bordered={false} title="AI briefing">
+        <Empty description="Select an event to see cross-source insights." />
+      </Card>
+    )
+  }
+
+  return (
+    <Card bordered={false} title="AI briefing" styles={{ body: { display: 'flex', flexDirection: 'column', gap: 16 } }}>
+      <Flex gap={12} wrap>
+        <Tag color="blue">{event.category}</Tag>
+        <Tag color={event.sentiment === 'positive' ? 'green' : event.sentiment === 'negative' ? 'red' : 'default'}>
+          Sentiment: {event.sentiment}
+        </Tag>
+        <Tag color="purple">Fresh update {dayjs().subtract(event.freshnessMinutes, 'minute').fromNow()}</Tag>
+      </Flex>
+      <Card size="small" title="AI synthesis" bordered>
+        <p>{event.aiSummary}</p>
+      </Card>
+      <div>
+        <SectionTitle>Recommended actions</SectionTitle>
+        <List
+          dataSource={event.recommendedActions}
+          renderItem={(item) => (
+            <List.Item key={item}>
+              <Flex align="center" gap={8}>
+                <CheckCircle2 size={16} />
+                <span>{item}</span>
+              </Flex>
+            </List.Item>
+          )}
+        />
+      </div>
+      <div>
+        <SectionTitle>Source timeline</SectionTitle>
+        <List
+          itemLayout="vertical"
+          dataSource={event.articles}
+          renderItem={(article) => (
+            <List.Item key={article.id}>
+              <Flex justify="space-between" align="center">
+                <div>
+                  <Flex align="center" gap={6}>
+                    <strong>{article.outlet}</strong>
+                    <Tag color={article.tone === 'positive' ? 'green' : article.tone === 'negative' ? 'red' : 'default'}>
+                      {article.tone}
+                    </Tag>
+                  </Flex>
+                  <Headline>{article.headline}</Headline>
+                  <small>{article.viewpoint}</small>
+                </div>
+                <Space direction="vertical" align="end">
+                  <span>{dayjs(article.publishedAt).fromNow()}</span>
+                  <Button
+                    size="small"
+                    type="link"
+                    icon={<Link2 size={14} />}
+                    href={article.url}
+                    target="_blank"
+                    rel="noreferrer">
+                    Open
+                  </Button>
+                </Space>
+              </Flex>
+            </List.Item>
+          )}
+        />
+      </div>
+      <Card size="small" title="Distribution intelligence" bordered>
+        <Flex vertical gap={8}>
+          <Flex gap={8} align="center">
+            <Workflow size={16} />
+            <span>{event.distributionNotes}</span>
+          </Flex>
+          <Space>
+            <Button icon={<Sparkles size={14} />}>Generate omni-channel draft</Button>
+            <Button icon={<PlayCircle size={14} />} type="primary">
+              Launch avatar briefing
+            </Button>
+          </Space>
+        </Flex>
+      </Card>
+    </Card>
+  )
+}
+
+type TrendSidebarProps = {
+  trends: TrendInsight[]
+  presets: typeof MOCK_PRESETS
+  plugins: MarketPlugin[]
+}
+
+/**
+ * 趋势与插件侧栏
+ */
+const TrendSidebar: FC<TrendSidebarProps> = ({ trends, presets, plugins }) => {
+  return (
+    <SidebarStack>
+      <Card bordered={false} title="Trend pulse" styles={{ body: { display: 'flex', flexDirection: 'column', gap: 12 } }}>
+        {trends.map((trend) => (
+          <TrendItem key={trend.id}>
+            <Flex justify="space-between" align="center">
+              <strong>{trend.topic}</strong>
+              <Tag color={trend.momentum === 'rising' ? 'green' : trend.momentum === 'falling' ? 'red' : 'gold'}>
+                {trend.momentum}
+              </Tag>
+            </Flex>
+            <Progress percent={trend.volume} showInfo={false} />
+            <small>{trend.highlight}</small>
+          </TrendItem>
+        ))}
+      </Card>
+
+      <Card bordered={false} title="Distribution playbooks">
+        <List
+          dataSource={presets}
+          renderItem={(preset) => (
+            <List.Item key={preset.id}>
+              <Flex vertical gap={4}>
+                <strong>{preset.channel}</strong>
+                <span>{preset.format}</span>
+                <small>{preset.cadence}</small>
+                <Tag>{preset.tone}</Tag>
+                <Tooltip title={preset.automation}>
+                  <Button size="small" icon={<Sparkles size={14} />}>Auto-build package</Button>
+                </Tooltip>
+              </Flex>
+            </List.Item>
+          )}
+        />
+      </Card>
+
+      <Card bordered={false} title="MCP marketplace">
+        <List
+          dataSource={plugins}
+          renderItem={(plugin) => (
+            <List.Item key={plugin.id}>
+              <Flex justify="space-between" align="center">
+                <div>
+                  <strong>{plugin.name}</strong>
+                  <div>{plugin.vendor}</div>
+                  <Space size={4} wrap>
+                    {plugin.capabilities.map((capability) => (
+                      <Tag key={capability} color="blue">
+                        {capability}
+                      </Tag>
+                    ))}
+                  </Space>
+                </div>
+                <Space direction="vertical" align="end">
+                  <Tag color="purple">{plugin.category}</Tag>
+                  <Tag color={plugin.status === 'certified' ? 'green' : 'orange'}>{plugin.status}</Tag>
+                  <Button size="small" icon={<Layers3 size={14} />}>Install</Button>
+                </Space>
+              </Flex>
+            </List.Item>
+          )}
+        />
+      </Card>
+
+      <Card bordered={false} title="Operational guardrails" styles={{ body: { display: 'flex', flexDirection: 'column', gap: 12 } }}>
+        <Flex align="center" justify="space-between">
+          <span>Fact-check SLA</span>
+          <Tag color="green">&lt; 5s</Tag>
+        </Flex>
+        <Flex align="center" justify="space-between">
+          <span>Deduplication accuracy</span>
+          <Tag color="blue">97%</Tag>
+        </Flex>
+        <Flex align="center" justify="space-between">
+          <span>Daily throughput</span>
+          <Tag color="cyan">10k+ stories</Tag>
+        </Flex>
+        <Flex align="center" gap={8}>
+          <AlertTriangle size={16} color="var(--color-warning)" />
+          <span>Connect ElevenLabs + digital avatar endpoints to enable voice briefings.</span>
+        </Flex>
+      </Card>
+
+      <Card bordered={false} title="Smart notes workspace">
+        <Flex vertical gap={12}>
+          <span>Auto-sync verified insights into the collaborative note hub.</span>
+          <Switch checked disabled />
+          <Button type="primary" icon={<Sparkles size={14} />}>Open knowledge notebook</Button>
+        </Flex>
+      </Card>
+    </SidebarStack>
+  )
+}
+
+type FactCheckModalProps = {
+  state: FactCheckState
+  onClose: () => void
+}
+
+/**
+ * 事实核查弹窗
+ */
+const FactCheckModal: FC<FactCheckModalProps> = ({ state, onClose }) => {
+  const { visible, loading, event, result } = state
+
+  return (
+    <Modal
+      open={visible}
+      onCancel={onClose}
+      onOk={onClose}
+      okText="Close"
+      title={event ? `Fact Check · ${event.title}` : 'Fact Check'}
+      confirmLoading={loading}
+      width={640}>
+      {loading && <p>Running Perplexity Sonar + MCP verification…</p>}
+      {!loading && result && (
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <Flex align="center" gap={8}>
+            <ShieldCheck size={18} />
+            <Tag color={result.verdict === 'verified' ? 'green' : result.verdict === 'needs_review' ? 'gold' : 'red'}>
+              {result.verdict.replace('_', ' ')}
+            </Tag>
+            <span>AI confidence {result.aiConfidence}% · {result.latencyMs}ms</span>
+          </Flex>
+          <p>{result.summary}</p>
+          <Divider style={{ margin: '8px 0' }} />
+          <SectionTitle>Reference set</SectionTitle>
+          <List
+            dataSource={result.references}
+            renderItem={(reference) => (
+              <List.Item key={reference.url}>
+                <Flex justify="space-between" align="center">
+                  <span>{reference.title}</span>
+                  <Space>
+                    <Tag color={reference.stance === 'supporting' ? 'green' : reference.stance === 'disputing' ? 'red' : 'blue'}>
+                      {reference.stance}
+                    </Tag>
+                    <Button size="small" type="link" href={reference.url} target="_blank" rel="noreferrer">
+                      View source
+                    </Button>
+                  </Space>
+                </Flex>
+              </List.Item>
+            )}
+          />
+          <SectionTitle>Risk notes</SectionTitle>
+          <List dataSource={result.riskNotes} renderItem={(note) => <List.Item key={note}>{note}</List.Item>} />
+        </Space>
+      )}
+    </Modal>
+  )
+}
+
+const PageContainer = styled.div`
+  display: flex;
+  flex: 1;
+  gap: 16px;
+  height: 100%;
+  padding: 16px 20px 20px;
+  background: var(--color-background);
+  color: var(--color-text);
+  overflow: hidden;
+`
+
+const FiltersColumn = styled.div`
+  width: 280px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 4px;
+`
+
+const FeedColumn = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow: hidden;
+`
+
+const TrendColumn = styled.div`
+  width: 320px;
+  min-width: 320px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  gap: 16px;
+  padding-right: 4px;
+`
+
+const EventList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+`
+
+const EventCardContainer = styled.div<{ $active: boolean }>`
+  border: 1px solid ${({ $active }) => ($active ? 'var(--color-primary)' : 'var(--border-color)')};
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: ${({ $active }) => ($active ? 'var(--color-primary-bg)' : 'var(--color-background-soft)')};
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: var(--color-primary);
+  }
+
+  .event-title {
+    font-weight: 600;
+  }
+`
+
+const Summary = styled.p`
+  margin: 0;
+  color: var(--color-text-2);
+`
+
+const Metrics = styled.div`
+  display: flex;
+  gap: 16px;
+  color: var(--color-text-2);
+
+  span {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+  }
+`
+
+const SectionTitle = styled.h4`
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+`
+
+const Headline = styled.p`
+  margin: 4px 0 0;
+  font-weight: 500;
+`
+
+const SidebarStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+const TrendItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`
+
+const Label = styled.div`
+  margin-bottom: 4px;
+  font-weight: 500;
+`
+
+export default NewsroomPage

--- a/src/renderer/src/pages/newsroom/mockData.ts
+++ b/src/renderer/src/pages/newsroom/mockData.ts
@@ -1,0 +1,253 @@
+import dayjs from 'dayjs'
+
+import type {
+  DistributionPreset,
+  MarketPlugin,
+  NewsroomEvent,
+  TrendInsight
+} from './types'
+
+const baseTime = dayjs()
+
+export const MOCK_EVENTS: NewsroomEvent[] = [
+  {
+    id: 'event-1',
+    title: 'Global Semiconductor Supply Chain Reconfiguration',
+    summary:
+      'Multiple policy announcements signal a coordinated move to diversify chip manufacturing beyond traditional hubs.',
+    aiSummary:
+      'Policy trackers flag synchronized incentives in the US, EU, and Southeast Asia. Analysts recommend preparing comparative briefings and targeted outreach for supply-side partners.',
+    category: 'Technology',
+    tags: ['Semiconductor', 'Geopolitics', 'Manufacturing'],
+    regions: ['North America', 'Europe', 'Southeast Asia'],
+    sentiment: 'neutral',
+    riskLevel: 'medium',
+    reliability: 88,
+    impactScore: 92,
+    coverageScore: 76,
+    freshnessMinutes: 48,
+    priority: 'high',
+    articles: [
+      {
+        id: 'source-1',
+        outlet: 'Reuters',
+        headline: 'US and EU unveil aligned subsidies to attract chip fabs',
+        url: 'https://example.com/reuters-chip-fabs',
+        publishedAt: baseTime.subtract(2, 'hour').toISOString(),
+        tone: 'neutral',
+        viewpoint: 'Policy announcement overview'
+      },
+      {
+        id: 'source-2',
+        outlet: 'Nikkei Asia',
+        headline: 'ASEAN nations pitch turnkey facilities for advanced nodes',
+        url: 'https://example.com/nikkei-asean-fabs',
+        publishedAt: baseTime.subtract(3, 'hour').toISOString(),
+        tone: 'positive',
+        viewpoint: 'Regional opportunity analysis'
+      },
+      {
+        id: 'source-3',
+        outlet: 'Perplexity Discover',
+        headline: 'Satellite data reveals construction uptick around new fab sites',
+        url: 'https://example.com/perplexity-fab-sites',
+        publishedAt: baseTime.subtract(80, 'minute').toISOString(),
+        tone: 'neutral',
+        viewpoint: 'Geo-intelligence corroboration'
+      }
+    ],
+    recommendedActions: [
+      'Draft executive brief comparing incentive packages',
+      'Schedule expert roundtable on resilient supply planning',
+      'Update partner CRM segments with new subsidy eligibility'
+    ],
+    distributionNotes:
+      'Focus LinkedIn thought leadership in neutral tone, highlight data-driven analysis on investor newsletter, and localize APAC outreach with actionable subsidy tables.'
+  },
+  {
+    id: 'event-2',
+    title: 'Breakthrough in Carbon Capture Storage Utilization',
+    summary:
+      'A consortium of climate-tech startups and public labs reports a 30% efficiency gain in modular carbon capture units.',
+    aiSummary:
+      'Perplexity Sonar synthesizes lab whitepapers, patent filings, and conference chatter to confirm replicable performance. Recommend preparing investor storyline and compliance FAQ.',
+    category: 'Climate',
+    tags: ['Carbon Capture', 'Sustainability', 'Energy'],
+    regions: ['Global'],
+    sentiment: 'positive',
+    riskLevel: 'low',
+    reliability: 93,
+    impactScore: 84,
+    coverageScore: 68,
+    freshnessMinutes: 25,
+    priority: 'medium',
+    articles: [
+      {
+        id: 'source-4',
+        outlet: 'Science Daily',
+        headline: 'Open-sourced dataset reveals dramatic efficiency jump',
+        url: 'https://example.com/sciencedaily-carbon-capture',
+        publishedAt: baseTime.subtract(35, 'minute').toISOString(),
+        tone: 'positive',
+        viewpoint: 'Research validation'
+      },
+      {
+        id: 'source-5',
+        outlet: 'TechCrunch',
+        headline: 'Climate consortium raises $120M to commercialize new CCS units',
+        url: 'https://example.com/techcrunch-ccs-funding',
+        publishedAt: baseTime.subtract(90, 'minute').toISOString(),
+        tone: 'positive',
+        viewpoint: 'Venture financing'
+      }
+    ],
+    recommendedActions: [
+      'Prepare ESG newsletter segment with FAQ on validation methods',
+      'Generate social snippets tailored for sustainability influencers',
+      'Queue demo script for investor webinar with voiceover'
+    ],
+    distributionNotes:
+      'Deploy optimistic tone for social channels, craft executive-friendly slides for LinkedIn documents, and trigger podcast script generation using ElevenLabs narration.'
+  },
+  {
+    id: 'event-3',
+    title: 'Regulatory Scrutiny Intensifies on Generative AI Transparency',
+    summary:
+      'Concurrent hearings in the EU and US demand clearer disclosure around training data and safety guardrails.',
+    aiSummary:
+      'Synchronized legal briefings and stakeholder memos indicate heightened compliance urgency. Recommend immediate policy tracker update and proactive outreach to enterprise clients.',
+    category: 'Policy',
+    tags: ['AI Governance', 'Compliance', 'Safety'],
+    regions: ['North America', 'Europe'],
+    sentiment: 'negative',
+    riskLevel: 'high',
+    reliability: 81,
+    impactScore: 88,
+    coverageScore: 71,
+    freshnessMinutes: 110,
+    priority: 'high',
+    articles: [
+      {
+        id: 'source-6',
+        outlet: 'Financial Times',
+        headline: 'Lawmakers push for algorithmic audit trail requirements',
+        url: 'https://example.com/ft-ai-audit-trail',
+        publishedAt: baseTime.subtract(4, 'hour').toISOString(),
+        tone: 'negative',
+        viewpoint: 'Legislative pressure'
+      },
+      {
+        id: 'source-7',
+        outlet: 'The Verge',
+        headline: 'Developers brace for cross-border compliance obligations',
+        url: 'https://example.com/verge-compliance',
+        publishedAt: baseTime.subtract(3, 'hour').toISOString(),
+        tone: 'neutral',
+        viewpoint: 'Industry reaction'
+      },
+      {
+        id: 'source-8',
+        outlet: 'Perplexity Sonar',
+        headline: 'Hearing transcripts highlight focus on training corpus disclosure',
+        url: 'https://example.com/sonar-hearing-transcripts',
+        publishedAt: baseTime.subtract(70, 'minute').toISOString(),
+        tone: 'neutral',
+        viewpoint: 'Evidence synthesis'
+      }
+    ],
+    recommendedActions: [
+      'Trigger client advisory email with compliance checklist',
+      'Schedule legal team sync with MCP regulatory plugins',
+      'Update newsroom briefing to include potential rollout timelines'
+    ],
+    distributionNotes:
+      'Adopt cautionary tone across social channels, push detailed compliance article to knowledge base, and generate scripted briefing for executive spokesperson avatar.'
+  }
+]
+
+export const MOCK_TRENDS: TrendInsight[] = [
+  {
+    id: 'trend-1',
+    topic: 'AI Safety Frameworks',
+    delta: 18,
+    momentum: 'rising',
+    volume: 87,
+    coverage: 72,
+    highlight: 'Policy hearings accelerated 18% week-over-week with regulator quotes gaining traction.'
+  },
+  {
+    id: 'trend-2',
+    topic: 'Sustainable Manufacturing',
+    delta: 9,
+    momentum: 'stable',
+    volume: 64,
+    coverage: 58,
+    highlight: 'Lifecycle analysis whitepapers shared widely across climate analyst newsletters.'
+  },
+  {
+    id: 'trend-3',
+    topic: 'Generative Video Tooling',
+    delta: -6,
+    momentum: 'falling',
+    volume: 41,
+    coverage: 39,
+    highlight: 'Buzz cooled after major vendors delayed feature rollouts pending compliance checks.'
+  }
+]
+
+export const MOCK_PRESETS: DistributionPreset[] = [
+  {
+    id: 'preset-1',
+    channel: 'LinkedIn',
+    format: 'Thought leadership carousel',
+    cadence: 'Publish within 2 hours of briefing',
+    tone: 'Analytical and neutral',
+    automation: 'Auto-generate slides + schedule via StoryChief API'
+  },
+  {
+    id: 'preset-2',
+    channel: 'Newsletter',
+    format: 'Executive digest email',
+    cadence: 'Daily 7:30 AM UTC',
+    tone: 'Concise and actionable',
+    automation: 'Draft via MCP summarizer, push to Mailchimp connector'
+  },
+  {
+    id: 'preset-3',
+    channel: 'Podcast',
+    format: '2-minute briefing script',
+    cadence: 'Triggered on high priority events',
+    tone: 'Authoritative with calm reassurance',
+    automation: 'Generate script + ElevenLabs narration + avatar render pipeline'
+  }
+]
+
+export const MOCK_PLUGINS: MarketPlugin[] = [
+  {
+    id: 'plugin-1',
+    name: 'Policy Radar Pro',
+    vendor: 'CivicSight Labs',
+    category: 'analysis',
+    apiEndpoint: 'https://api.civicsight.ai/radar',
+    capabilities: ['Regulatory diffing', 'Hearing transcript summarization', 'Geo-tag filtering'],
+    status: 'certified'
+  },
+  {
+    id: 'plugin-2',
+    name: 'Signal Deduplicator',
+    vendor: 'Veracity MCP',
+    category: 'connector',
+    apiEndpoint: 'https://mcp.veracity.ai/deduplicate',
+    capabilities: ['Content fingerprinting', 'Event clustering', 'Anomaly scoring'],
+    status: 'certified'
+  },
+  {
+    id: 'plugin-3',
+    name: 'VoiceCaster Studio',
+    vendor: 'Nova Voices',
+    category: 'content',
+    apiEndpoint: 'https://api.novavoices.ai/render',
+    capabilities: ['ElevenLabs bridge', 'Avatar staging', 'Tone guardrails'],
+    status: 'beta'
+  }
+]

--- a/src/renderer/src/pages/newsroom/types.ts
+++ b/src/renderer/src/pages/newsroom/types.ts
@@ -1,0 +1,98 @@
+export type SentimentLabel = 'positive' | 'neutral' | 'negative'
+
+export type TrendMomentum = 'rising' | 'stable' | 'falling'
+
+export type RiskLevel = 'high' | 'medium' | 'low'
+
+export type NewsroomTimeframe = '1h' | '6h' | '24h' | '7d'
+
+export type PluginCategory = 'analysis' | 'content' | 'ai-assistant' | 'connector'
+
+export type FactCheckVerdict = 'verified' | 'needs_review' | 'debunked'
+
+export type FactCheckReferenceStance = 'supporting' | 'disputing' | 'neutral'
+
+export type NewsroomFilterState = {
+  timeframe: NewsroomTimeframe
+  categories: string[]
+  regions: string[]
+  sentiment: 'all' | SentimentLabel
+  risk: 'all' | RiskLevel
+  sources: string[]
+  query: string
+  onlyPriority: boolean
+}
+
+export type SourceArticle = {
+  id: string
+  outlet: string
+  headline: string
+  url: string
+  publishedAt: string
+  tone: SentimentLabel
+  viewpoint: string
+}
+
+export type NewsroomEvent = {
+  id: string
+  title: string
+  summary: string
+  aiSummary: string
+  category: string
+  tags: string[]
+  regions: string[]
+  sentiment: SentimentLabel
+  riskLevel: RiskLevel
+  reliability: number
+  impactScore: number
+  coverageScore: number
+  freshnessMinutes: number
+  priority: RiskLevel
+  articles: SourceArticle[]
+  recommendedActions: string[]
+  distributionNotes: string
+}
+
+export type TrendInsight = {
+  id: string
+  topic: string
+  delta: number
+  momentum: TrendMomentum
+  volume: number
+  coverage: number
+  highlight: string
+}
+
+export type DistributionPreset = {
+  id: string
+  channel: string
+  format: string
+  cadence: string
+  tone: string
+  automation: string
+}
+
+export type MarketPlugin = {
+  id: string
+  name: string
+  vendor: string
+  category: PluginCategory
+  apiEndpoint: string
+  capabilities: string[]
+  status: 'certified' | 'beta'
+}
+
+export type FactCheckReference = {
+  title: string
+  url: string
+  stance: FactCheckReferenceStance
+}
+
+export type FactCheckInsight = {
+  verdict: FactCheckVerdict
+  summary: string
+  references: FactCheckReference[]
+  riskNotes: string[]
+  aiConfidence: number
+  latencyMs: number
+}

--- a/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
@@ -18,6 +18,7 @@ import {
   Folder,
   Languages,
   LayoutGrid,
+  Newspaper,
   MessageSquareQuote,
   NotepadText,
   Palette,
@@ -127,7 +128,8 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
       knowledge: <FileSearch size={16} />,
       files: <Folder size={16} />,
       notes: <NotepadText size={16} />,
-      code_tools: <Code size={16} />
+      code_tools: <Code size={16} />,
+      newsroom: <Newspaper size={16} />
     }),
     []
   )

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2476,6 +2476,23 @@ const migrateConfig = {
       logger.error('migrate 155 error', error as Error)
       return state
     }
+  },
+  '156': (state: RootState) => {
+    try {
+      if (state.settings && state.settings.sidebarIcons) {
+        if (!state.settings.sidebarIcons.visible.includes('newsroom')) {
+          state.settings.sidebarIcons.visible.push('newsroom')
+        }
+        state.settings.sidebarIcons.visible = [...new Set(state.settings.sidebarIcons.visible)].filter((icon) =>
+          DEFAULT_SIDEBAR_ICONS.includes(icon)
+        )
+        state.settings.sidebarIcons.disabled = state.settings.sidebarIcons.disabled.filter((icon) => icon !== 'newsroom')
+      }
+      return state
+    } catch (error) {
+      logger.error('migrate 156 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -676,6 +676,7 @@ export type SidebarIcon =
   | 'files'
   | 'code_tools'
   | 'notes'
+  | 'newsroom'
 
 export type ExternalToolResult = {
   mcpTools?: MCPTool[]


### PR DESCRIPTION
## Summary
- add a mock-driven Newsroom page that showcases RSS-style aggregation, AI fact checking, trend analysis, distribution, and MCP plugin surfaces for Newside Studio
- register the Newsroom workspace throughout the app navigation, default sidebar configuration, and translations
- seed migration, types, and mock data structures so the new sidebar icon and filters stay consistent across user settings

## Testing
- yarn typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68cb177f30d0832a9858bec5020be4e1